### PR TITLE
NOTIFYRE-2166-SDK-Fax #comment Fax request fix

### DIFF
--- a/src/Notifyre/Constants/DocumentConversionStatusType.cs
+++ b/src/Notifyre/Constants/DocumentConversionStatusType.cs
@@ -2,9 +2,10 @@
 {
     public static class DocumentConversionStatusType
     {
-        public const string Completed = "Completed";
-        public const string Failed = "Failed";
-        public const string Timeout = "Timeout";
+        public const string Converting = "converting";
+        public const string Failed = "failed";
+        public const string Initialised = "initialised";
+        public const string Successful = "successful";
 
     }
 }

--- a/src/Notifyre/Services/Fax/FaxSend/DownloadFax/DownloadFaxRequest.cs
+++ b/src/Notifyre/Services/Fax/FaxSend/DownloadFax/DownloadFaxRequest.cs
@@ -5,7 +5,7 @@ namespace Notifyre
 {
     public class DownloadFaxRequest
     {
-        public Guid ID { get; set; }
+        public Guid RecipientID { get; set; }
         [QueryParam(typeof(FileTypes))]
         public DownloadFaxRequestFileTypes FileType { get; set; }
 

--- a/src/Notifyre/Services/Fax/FaxSend/SubmitFax/GetDocumentStatus/GetDocumentStatusRequest.cs
+++ b/src/Notifyre/Services/Fax/FaxSend/SubmitFax/GetDocumentStatus/GetDocumentStatusRequest.cs
@@ -5,7 +5,7 @@ namespace Notifyre.Services.Fax.FaxSend.SubmitFax.GetDocumentStatus
     internal class GetDocumentStatusRequest
     {
         [RouteParam]
-        public string ID { get; set; }
+        public string FileName { get; set; }
 
     }
 }

--- a/src/Notifyre/Services/Fax/FaxSend/SubmitFax/SubmitFaxRequest.cs
+++ b/src/Notifyre/Services/Fax/FaxSend/SubmitFax/SubmitFaxRequest.cs
@@ -101,7 +101,7 @@ namespace Notifyre
     {
         public const string FaxNumber = "fax_number";
         public const string Contact = "contact";
-        public const string Group = "Group";
+        public const string Group = "group";
 
     }
 

--- a/src/NotifyreTests/Services/Fax/FaxSend/FaxSendServiceTests.cs
+++ b/src/NotifyreTests/Services/Fax/FaxSend/FaxSendServiceTests.cs
@@ -115,7 +115,7 @@ namespace NotifyreTests.Services.Fax.FaxSend
             var request = new DownloadFaxRequest()
             {
                 FileType = DownloadFaxRequestFileTypes.Pdf,
-                ID = new Guid("9aca0071-2b61-4beb-bad2-a3ec8ce611e5")
+                RecipientID = new Guid("9aca0071-2b61-4beb-bad2-a3ec8ce611e5")
             };
 
             // Act 

--- a/src/NotifyreTests/Services/HttpHandlerFake.cs
+++ b/src/NotifyreTests/Services/HttpHandlerFake.cs
@@ -72,11 +72,11 @@ namespace NotifyreTests.Services
                 }
                 else if (_statusAttempts == 1 || _statusAttempts == 2)
                 {
-                    msg = "{\"payload\":{\"id\":\"6787bea0-d222-4870-811b-1192eef28b34\",\"status\":\"Routed\",\"pages\":null,\"fileName\":\"f1a901c1-a4b7-4a43-b00d-15da02fca38d\"},\"success\":true,\"statusCode\":200,\"message\":\"OK\",\"errors\":[]}";
+                    msg = "{\"payload\":{\"id\":\"6787bea0-d222-4870-811b-1192eef28b34\",\"status\":\"converting\",\"pages\":null,\"fileName\":\"f1a901c1-a4b7-4a43-b00d-15da02fca38d\"},\"success\":true,\"statusCode\":200,\"message\":\"OK\",\"errors\":[]}";
                 }
                 else
                 {
-                    msg = "{\"payload\":{\"id\":\"6787bea0-d222-4870-811b-1192eef28b34\",\"status\":\"Completed\",\"pages\":1,\"fileName\":\"f1a901c1-a4b7-4a43-b00d-15da02fca38d\"},\"success\":true,\"statusCode\":200,\"message\":\"OK\",\"errors\":[]}";
+                    msg = "{\"payload\":{\"id\":\"6787bea0-d222-4870-811b-1192eef28b34\",\"status\":\"successful\",\"pages\":1,\"fileName\":\"f1a901c1-a4b7-4a43-b00d-15da02fca38d\"},\"success\":true,\"statusCode\":200,\"message\":\"OK\",\"errors\":[]}";
                 }
                 _statusAttempts++;
             }


### PR DESCRIPTION
Submit Fax:
- Increase the timeout time while checking for the upload status
- Fix the ID sent to the SubmitFaxCommand. Id sent before was the kafka corellationId.
- Update DocumentConversionStatusType

Download Fax
- Change the property name for consistency with the API ID->ReceipientID

Unit Test
- Update the status returned by HTTPHandlerFake